### PR TITLE
fix acf import/export of fancy repeater fields

### DIFF
--- a/acf-fancy-repeater-field-v5.php
+++ b/acf-fancy-repeater-field-v5.php
@@ -53,10 +53,10 @@ class ACF_Fancy_Repeater_Field_V5 {
 			$field['use_fancy_repeater'] = isset( $field['use_fancy_repeater'] ) ? $field['use_fancy_repeater'] : 'no';
 			$field['forced_fancy_repeater'] = false;
 			if ( $field['use_fancy_repeater'] == 'yes' ) {
-                                //only change the field type if we aren't exporting
-                                if( sanitize_text_field( $_REQUEST['page'] ) != 'acf-settings-tools' ) {
-                                        $field['type'] = 'fancyrepeater';
-                                }
+				//only change the field type if we aren't exporting
+				if( !isset($_REQUEST['page']) || ( sanitize_text_field( $_REQUEST['page'] ) != 'acf-settings-tools' ) ) {
+					$field['type'] = 'fancyrepeater';
+				}
 				$field['forced_fancy_repeater'] = true;
 			}
 		}

--- a/acf-fancy-repeater-field-v5.php
+++ b/acf-fancy-repeater-field-v5.php
@@ -53,7 +53,10 @@ class ACF_Fancy_Repeater_Field_V5 {
 			$field['use_fancy_repeater'] = isset( $field['use_fancy_repeater'] ) ? $field['use_fancy_repeater'] : 'no';
 			$field['forced_fancy_repeater'] = false;
 			if ( $field['use_fancy_repeater'] == 'yes' ) {
-				$field['type'] = 'fancyrepeater';
+                                //only change the field type if we aren't exporting
+                                if( sanitize_text_field( $_REQUEST['page'] ) != 'acf-settings-tools' ) {
+                                        $field['type'] = 'fancyrepeater';
+                                }
 				$field['forced_fancy_repeater'] = true;
 			}
 		}


### PR DESCRIPTION
fix issue #6 - since the project overrides the field group type to use the filters, the export process was taking the overridden type "fancyrepeater" instead of using the base type "repeater" since the field type technically is to remain "repeater" for export/import - since the load_field filter is called during the export process, we simply check if we are on the tools page before deciding to override the field type